### PR TITLE
User Story 3

### DIFF
--- a/app/controllers/merchants/discounts_controller.rb
+++ b/app/controllers/merchants/discounts_controller.rb
@@ -22,6 +22,11 @@ class Merchants::DiscountsController < ApplicationController
     end
   end
 
+  def destroy
+    Discount.find(params[:id]).destroy
+    redirect_to merchant_discounts_path
+  end
+
   private
 
   def discount_params

--- a/app/views/merchants/discounts/index.html.erb
+++ b/app/views/merchants/discounts/index.html.erb
@@ -3,6 +3,8 @@
 <% @merchant.discounts.each do |discount| %>
   <p><%= "#{discount.id}. #{(discount.percentage * 100).round(0)}% off, after #{discount.quantity} of any item purchased" %></p>
   <p>More about discount number <%= link_to "#{discount.id}", merchant_discount_path(@merchant, discount) %></p>
+   <%= button_to "Delete Discount #{discount.id}", merchant_discount_path(@merchant, discount), method: :delete %>
+
 <% end %>
 
 <%= link_to "Create a New Discount", new_merchant_discount_path%>

--- a/app/views/merchants/discounts/show.html.erb
+++ b/app/views/merchants/discounts/show.html.erb
@@ -1,0 +1,1 @@
+<h3><%="Discount #{@discount.id} Show Page %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,13 @@ Rails.application.routes.draw do
     
     resources :invoices, controller: "merchants/invoices", only: [:show, :index, :update]
 
-    resources :discounts, controller: "merchants/discounts", only: [:index, :show, :new, :create]
+    resources :discounts, controller: "merchants/discounts", only: [:index, :show, :new, :create, :destroy]
   end
 
   namespace :merchants do
     resources :invoices, only: [:index, :update]
     resources :items, only: :show
-    resources :discounts, only: [:index, :show, :new, :create]
+    resources :discounts, only: [:index, :show, :new, :create, :delete]
   end
   
   root "merchants#index"

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "merchant discounts index page" do
     visit "/merchants/#{@merchant_1.id}/discounts"
     expect(page).to have_button("Delete Discount #{@discount_1.id}")
     click_on("Delete Discount #{@discount_1.id}")
-    expect(current_path).to eq((merchant_discounts_path(@merchant_1))
+    expect(current_path).to eq((merchant_discounts_path(@merchant_1)))
     expect(page).to_not have_content("#{@discount_1.id}")
   end
 end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -20,4 +20,13 @@ RSpec.describe "merchant discounts index page" do
     expect(page).to have_link("#{@discount_2.id}")
     click_on("#{@discount_1.id}")
   end
+
+  #Discounts US 3
+  it "has a button to delete a discount" do
+    visit "/merchants/#{@merchant_1.id}/discounts"
+    expect(page).to have_button("Delete Discount #{@discount_1.id}")
+    click_on("Delete Discount #{@discount_1.id}")
+    expect(current_path).to eq((merchant_discounts_path(@merchant_1))
+    expect(page).to_not have_content("#{@discount_1.id}")
+  end
 end


### PR DESCRIPTION
3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a button to delete it
When I click this button
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed