### PR TITLE
User story 5

### DIFF
--- a/app/controllers/merchants/discounts_controller.rb
+++ b/app/controllers/merchants/discounts_controller.rb
@@ -27,6 +27,23 @@ class Merchants::DiscountsController < ApplicationController
     redirect_to merchant_discounts_path
   end
 
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+    @discount = Discount.find(params[:id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @discount = Discount.find(params[:id])
+    if @discount.update(discount_params)
+      redirect_to merchant_discount_path(@merchant, @discount)
+      flash[:alert] = "Discount successfully updated"
+    else
+      redirect_to edit_merchant_discount_path(@merchant, @discount)
+      flash[:alert] = "Discount update failed"
+    end
+  end
+
   private
 
   def discount_params

--- a/app/views/merchants/discounts/edit.html.erb
+++ b/app/views/merchants/discounts/edit.html.erb
@@ -1,0 +1,11 @@
+<section id="update_discount_form">
+  <%= form_with url: merchant_discount_path(@merchant, @discount), method: :patch, data: { turbo: false }, local: true do |form| %>
+    <%= form.label :percentage %>
+    <%= form.text_field :percentage, value: @discount.percentage %>
+
+    <%= form.label :quantity %>
+    <%= form.text_field :quantity, value: @discount.quantity %>
+
+    <%= form.submit "Update Discount" %>
+  <% end %>
+</section>

--- a/app/views/merchants/discounts/index.html.erb
+++ b/app/views/merchants/discounts/index.html.erb
@@ -1,10 +1,11 @@
 <h1><%= "Merchant '#{@merchant.name}' Discounts Index" %></h1>
-
-<% @merchant.discounts.each do |discount| %>
-  <p><%= "#{discount.id}. #{(discount.percentage * 100).round(0)}% off, after #{discount.quantity} of any item purchased" %></p>
-  <p>More about discount number <%= link_to "#{discount.id}", merchant_discount_path(@merchant, discount) %></p>
-   <%= button_to "Delete Discount #{discount.id}", merchant_discount_path(@merchant, discount), method: :delete %>
-
-<% end %>
-
+<section id = "discounts index">
+  <% @merchant.discounts.each do |discount| %>
+  <section id="discount-<%= discount.id %>">
+    <p><%= "#{discount.id}. #{(discount.percentage * 100).round(0)}% off, after #{discount.quantity} of any item purchased" %></p>
+    <p>More about discount number <%= link_to "#{discount.id}", merchant_discount_path(@merchant, discount) %></p>
+    <%= button_to "Delete Discount #{discount.id}", merchant_discount_path(@merchant, discount), method: :delete %>
+  </section>
+  <% end %>
+</section>
 <%= link_to "Create a New Discount", new_merchant_discount_path%>

--- a/app/views/merchants/discounts/show.html.erb
+++ b/app/views/merchants/discounts/show.html.erb
@@ -1,2 +1,4 @@
 <h3><%="Discount #{@discount.id} Show Page" %></h3>
 <p><%= "#{(@discount.percentage * 100).round(0)}% off, after #{@discount.quantity} of any item purchased"%>
+
+<%= link_to "Edit Discount #{@discount.id} Details", edit_merchant_discount_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,13 @@ Rails.application.routes.draw do
     
     resources :invoices, controller: "merchants/invoices", only: [:show, :index, :update]
 
-    resources :discounts, controller: "merchants/discounts", only: [:index, :show, :new, :create, :destroy]
+    resources :discounts, controller: "merchants/discounts", only: [:index, :show, :new, :create, :destroy, :update, :edit]
   end
 
   namespace :merchants do
     resources :invoices, only: [:index, :update]
     resources :items, only: :show
-    resources :discounts, only: [:index, :show, :new, :create, :delete]
+    resources :discounts, only: [:index, :show, :new, :create, :delete, :edit]
   end
   
   root "merchants#index"

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "merchant discounts edit page" do
+  before :each do
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+    @discount_1 = @merchant_1.discounts.create(percentage: 0.5, quantity: 40)
+    @discount_2 = @merchant_1.discounts.create(percentage: 0.1, quantity: 5)
+    @discount_3 = @merchant_2.discounts.create(percentage: 0.15, quantity: 5)
+  end
+
+  it "allows a merchant to edit their discounts" do
+    visit (merchant_discount_show_path(@merchant_1, @discount_1))
+    expect(page).to have_content("Discount #{@discount_1} Show Page")
+
+  end
+end

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -9,9 +9,36 @@ RSpec.describe "merchant discounts edit page" do
     @discount_3 = @merchant_2.discounts.create(percentage: 0.15, quantity: 5)
   end
 
-  it "allows a merchant to edit their discounts" do
-    visit (merchant_discount_show_path(@merchant_1, @discount_1))
-    expect(page).to have_content("Discount #{@discount_1} Show Page")
+  it "is linked from the discount show page" do
+    visit merchant_discount_path(@merchant_1, @discount_1)
+    expect(page).to have_content("Discount #{@discount_1.id} Show Page")
+    expect(page).to have_link("Edit Discount #{@discount_1.id} Details")
+    click_link("Edit Discount #{@discount_1.id} Details")
+    expect(current_path).to eq("/merchants/#{@merchant_1.id}/discounts/#{@discount_1.id}/edit")
+  end
 
+  it "is prefilled with discount attributes" do
+    visit edit_merchant_discount_path(@merchant_1, @discount_1)
+    expect(page).to have_field(:percentage, with: @discount_1.percentage)
+    expect(page).to have_field(:quantity, with: @discount_1.quantity)
+    expect(page).to have_button("Update Discount")
+  end
+
+  it "updates attributes and redirects to discount show page" do
+    visit edit_merchant_discount_path(@merchant_1, @discount_1)
+    fill_in "percentage", with: 0.6
+    fill_in "quantity", with: 40
+    click_button "Update Discount"
+    expect(current_path).to eq("/merchants/#{@merchant_1.id}/discounts/#{@discount_1.id}")
+    expect(page).to have_content("60% off, after 40 of any item purchased")
+    expect(page).to have_content("Discount successfully updated")
+  end
+
+  it "shows an error if a field is left blank" do
+    visit edit_merchant_discount_path(@merchant_1, @discount_1)
+    fill_in "percentage", with: ""
+    click_button "Update Discount"
+    expect(current_path).to eq("/merchants/#{@merchant_1.id}/discounts/#{@discount_1.id}/edit")
+    expect(page).to have_content("Discount update failed")
   end
 end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -12,11 +12,12 @@ RSpec.describe "merchant discounts index page" do
   #Discounts US 1
   it "shows all a merchant's bulk discounts" do
     visit "/merchants/#{@merchant_1.id}/discounts"
-
-    expect(page).to have_content("#{@discount_1.id}. #{(@discount_1.percentage * 100).round(0)}% off, after #{@discount_1.quantity} of any item purchased")
+    within("#discount-#{@discount_1.id}") do
+      expect(page).to have_content("#{@discount_1.id}. #{(@discount_1.percentage * 100).round(0)}% off, after #{@discount_1.quantity} of any item purchased")
+      expect(page).to have_link("#{@discount_1.id}")
+    end
     expect(page).to have_content("#{@discount_2.id}. #{(@discount_2.percentage * 100).round(0)}% off, after #{@discount_2.quantity} of any item purchased")
     expect(page).to_not have_content("#{@discount_3.percentage}")
-    expect(page).to have_link("#{@discount_1.id}")
     expect(page).to have_link("#{@discount_2.id}")
     click_on("#{@discount_1.id}")
   end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated